### PR TITLE
Further integration, bug fixes

### DIFF
--- a/denote-citar.el
+++ b/denote-citar.el
@@ -64,7 +64,18 @@
     (denote
      ;; Replace underscores in citation key
      (replace-regexp-in-string "_" "-" key)
-     (denote-citar--keywords-prompt))
+     (denote-citar--keywords-prompt)
+     nil ;; use default file type
+     ;; We use `citar-notes-paths' to allow the user to configure
+     ;; subdirectories. This is a list. If it has only one element, we
+     ;; use it as the path. Otherwise, we ask the user to specify which
+     ;; path to use. We use `<=' when checking the length of
+     ;; `citar-notes-paths' as if the if list is empty, this will
+     ;; place the note in the default location (`denote-directory').
+     (if (<= (length citar-notes-paths) 1)
+	 (car citar-notes-paths)
+       (completing-read "Please choose which folder to store the note:"
+			citar-notes-paths nil t)))
     (with-current-buffer (current-buffer) ;; This is the buffer
 					  ;; created by denote
       (save-excursion

--- a/denote-citar.el
+++ b/denote-citar.el
@@ -144,6 +144,14 @@ If optional KEY is non-nil, return the key instead."
                  (puthash key (nreverse filelist) files))
 	       files))))
 
+;; This is modified version of `citar-file--has-notes'. It uses our
+;; own "get-notes" function. The original function utilises `let', but
+;; that for some reason does not work here.
+(defun denote-citar--has-notes ()
+  (setq notes (denote-citar--get-notes))
+    (unless (hash-table-empty-p notes)
+      (lambda (citekey) (and (gethash citekey notes) t))))
+
 ;; Modify the way Citar links notes to bibliographies
 (setq citar-notes-sources
       `((citar-file .

--- a/denote-citar.el
+++ b/denote-citar.el
@@ -152,15 +152,13 @@ If optional KEY is non-nil, return the key instead."
     (unless (hash-table-empty-p notes)
       (lambda (citekey) (and (gethash citekey notes) t))))
 
-;; Modify the way Citar links notes to bibliographies
-(setq citar-notes-sources
-      `((citar-file .
-                    ,(list :name "Notes"
-                           :category 'file
-                           :items #'citar-file--get-notes
-                           :hasitems #'citar-file--has-notes
-                           :open #'find-file
-                           :create #'denote-citar-file--create-note
-                           :transform #'file-name-nondirectory))))
+(citar-register-notes-source
+ 'denote-citar-source (list :name "Denote Notes"
+			    :category 'file
+			    :items 'denote-citar--get-notes
+			    :hasitems 'denote-citar--has-notes
+			    :open 'find-file
+                            :create 'denote-citar-file--create-note))
+(setq citar-notes-source 'denote-citar-source)
 
 (provide 'denote-citar)

--- a/denote-citar.el
+++ b/denote-citar.el
@@ -65,11 +65,14 @@
      ;; Replace underscores in citation key
      (replace-regexp-in-string "_" "-" key)
      (denote-citar--keywords-prompt))
-    ;; The `denote-last-buffer' is the one we just created with `denote'.
-    (with-current-buffer (get-buffer denote-last-buffer)
+    (with-current-buffer (current-buffer) ;; This is the buffer
+					  ;; created by denote
       (save-excursion
 	(goto-char (point-min))
-	(re-search-forward denote-retrieve--id-front-matter-key-regexp)
+	;; Find the end of the front matter and insert the key there.
+	;; This can probably be solved in a better way.
+	(re-search-forward "^[^#]")
+	(search-backward "#")
 	(goto-char (point-at-eol))
         (newline)
         (insert (format "#+reference:  %s" key))))))


### PR DESCRIPTION
This PR adresses #2. In short, the following changes were made:

- Remove the use of obsolete symbols `denote-last-buffer` and `denote-retrieve--id-front-matter-key-regexpl`.
- Add support for `citar-notes-path` and multiple possible paths for notes.
- Add support for opening existing notes (functions `denote-citar--get-notes` and `denote-citar--has-notes`). Also change how `denote-citar` register the new notes source.

It's been a while since I used `git` (I also tried learning `magit`while making these commits) or did a PR. Hopefully everything is correct.